### PR TITLE
[BUGFIX] Use correct extension key for automatic PageTS loading

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -12,7 +12,7 @@ use TYPO3\CMS\Extbase\Utility\ExtensionUtility;
     // @see https://docs.typo3.org/m/typo3/reference-tsconfig/12.4/en-us/UsingSetting/PageTSconfig.html#pagesettingdefaultpagetsconfig
     if ($versionInformation->getMajorVersion() < 12) {
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('
-            @import \'EXT:academic_programs/Configuration/page.tsconfig\'
+            @import \'EXT:academic_projects/Configuration/page.tsconfig\'
         ');
     }
 


### PR DESCRIPTION
Due to copy&paste of ext_localconf.php snippet
to automatically load the extension PageTS the
extension key has not been changed which leads
to

```
Illegal filepath "EXT:academic_programs/Configuration/page.tsconfig"
```

errors spamming instance log files.

This change uses the correct extension key now.
