### PR TITLE
[TASK] Maintain `composer.json` and `ext_emconf.php`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,63 +1,69 @@
 {
-	"name": "fgtclb/academic-projects",
-	"description": "Research project page for universities. Ships structured data preparation",
-	"type": "typo3-cms-extension",
-	"license": [
-		"GPL-2.0-or-later"
-	],
-	"require": {
-		"php": "^8.1",
-		"ext-pdo": "*",
-		"typo3/cms-core": "^11.5",
-		"typo3/cms-backend": "^11.5",
-		"typo3/cms-extbase": "^11.5",
-		"typo3/cms-fluid": "^11.5",
-		"typo3/cms-install": "^11.5",
-		"fgtclb/category-types": "^1.0"
-	},
-	"require-dev": {
-		"friendsofphp/php-cs-fixer": "^3.0",
-		"helhum/typo3-console": "^5.8 || ^6.7 || ^7.1",
-		"helmich/typo3-typoscript-lint": "^2.5",
-		"nikic/php-parser": "^4.15.1",
-		"phpstan/phpstan": "^1.3",
-		"saschaegerer/phpstan-typo3": "^1.0",
-		"typo3/testing-framework": "^7.0"
-	},
-	"autoload": {
-		"psr-4": {
-			"FGTCLB\\AcademicProjects\\": "Classes/"
-		}
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"FGTCLB\\AcademicProjects\\Tests\\": "Tests"
-		}
-	},
-	"config": {
-		"vendor-dir": ".Build/vendor",
-		"bin-dir": ".Build/bin",
-		"allow-plugins": true
-	},
-	"extra": {
-		"typo3/cms": {
-			"web-dir": ".Build/Web",
-			"app-dir": ".Build",
-			"extension-key": "academic_projects"
-		}
-	},
-	"scripts": {
-		"cs:check": ".Build/bin/php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi --diff --verbose --dry-run",
-		"cs:fix": ".Build/bin/php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi",
-		"analyze:php": ".Build/bin/phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/Core11/phpstan.neon",
-		"analyze:baseline": ".Build/bin/phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/Core11/phpstan.neon --generate-baseline=Build/phpstan/Core11/phpstan-baseline.neon",
-		"lint:typoscript": ".Build/bin/typoscript-lint --ansi --config=./Build/typoscript-lint/typoscript-lint.yml",
-		"lint:php": "find .*.php *.php Classes Configuration Tests -name '*.php' -print0 | xargs -r -0 -n 1 -P 4 php -l",
-		"test:php": [
-			"@test:php:unit",
-			"@test:php:functional"
-		],
-		"test:php:unit": ".Build/bin/phpunit --colors=always --configuration Build/phpunit/UnitTests.xml",
-		"test:php:functional": "@test:php:unit --configuration Build/phpunit/FunctionalTests.xml"
-	}
+    "name": "fgtclb/academic-projects",
+    "description": "Research project page for universities. Ships structured data preparation",
+    "type": "typo3-cms-extension",
+    "license": [
+        "GPL-2.0-or-later"
+    ],
+    "require": {
+        "php": "^8.1 || ^8.2 || ^8.3",
+        "fgtclb/category-types": "^1.1.0 || 1.*.*@dev",
+        "typo3/cms-backend": "^11.5",
+        "typo3/cms-core": "^11.5",
+        "typo3/cms-extbase": "^11.5",
+        "typo3/cms-fluid": "^11.5",
+        "typo3/cms-install": "^11.5"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.0",
+        "helhum/typo3-console": "^5.8 || ^6.7 || ^7.1",
+        "helmich/typo3-typoscript-lint": "^2.5",
+        "nikic/php-parser": "^4.15.1",
+        "phpstan/phpstan": "^1.3",
+        "saschaegerer/phpstan-typo3": "^1.0",
+        "typo3/testing-framework": "^7.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "FGTCLB\\AcademicProjects\\": "Classes/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "FGTCLB\\AcademicProjects\\Tests\\": "Tests"
+        }
+    },
+    "config": {
+        "vendor-dir": ".Build/vendor",
+        "bin-dir": ".Build/bin",
+        "allow-plugins": true,
+        "sort-packages": true
+    },
+    "extra": {
+        "typo3/cms": {
+            "web-dir": ".Build/Web",
+            "app-dir": ".Build",
+            "extension-key": "academic_projects"
+        },
+        "branch-alias": {
+            "dev-main": "1.x.x-dev"
+        }
+    },
+    "scripts": {
+        "cs:check": ".Build/bin/php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi --diff --verbose --dry-run",
+        "cs:fix": ".Build/bin/php-cs-fixer fix --config Build/php-cs-fixer/php-cs-rules.php --ansi",
+        "analyze:php": ".Build/bin/phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/Core11/phpstan.neon",
+        "analyze:baseline": ".Build/bin/phpstan analyse --ansi --no-progress --memory-limit=768M --configuration=Build/phpstan/Core11/phpstan.neon --generate-baseline=Build/phpstan/Core11/phpstan-baseline.neon",
+        "lint:typoscript": ".Build/bin/typoscript-lint --ansi --config=./Build/typoscript-lint/typoscript-lint.yml",
+        "lint:php": "find .*.php *.php Classes Configuration Tests -name '*.php' -print0 | xargs -r -0 -n 1 -P 4 php -l",
+        "test:php": [
+            "@test:php:unit",
+            "@test:php:functional"
+        ],
+        "test:php:unit": ".Build/bin/phpunit --colors=always --configuration Build/phpunit/UnitTests.xml",
+        "test:php:functional": "@test:php:unit --configuration Build/phpunit/FunctionalTests.xml"
+    },
+    "conflict": {
+        "fgtclb/category-types": "<1.0.0 || >=2.0.0"
+    }
 }

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 $EM_CONF[$_EXTKEY] = [
     'title' => '(FGTCLB) Academic Projects',
     'description' => 'Academic project pages for TYPO3 with specific structured data and typed sys_categories',
@@ -11,7 +9,11 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'typo3' => '11.5.0-11.5.99',
-            'fgtclb_educational' => '*',
+            'backend' => '11.5.0-11.5.99',
+            'extbase' => '11.5.0-11.5.99',
+            'fluid' => '11.5.0-11.5.99',
+            'install' => '11.5.0-11.5.99',
+            'category_types' => '1.0.0-1.99.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
This change does minor maintenance work on the
`composer.json` and `ext_emconf.php` files.

* Remove PHP-Extension PDO as direct requirement,
  as no constants are used within the own code
  base.
* Set branch alias for main branch to `1.x.x-dev`.
* Update PHP version constraint in `composer.json`.
* Update `fgtclb/category-types` constraint within
  `composer.json` and add conflict for unsupported
  versions.
* Remove invalid `fgtclb_educational` extension key
  as dependency from `ext_emconf.php`.
* Remove invalid `declare(strict_types=1);` from the
  `ext_emconf.php` file, otherwise TER release will
  fail.
* Align `ext_emconf.php` dependencies with defined
  list in `composer.json`.

Used command(s):

```shell
composer remove --no-update \
  "ext-pdo" \
&& composer config \
  extra.branch-alias.dev-main "1.x.x-dev" \
&& composer config sort-packages true \
&& composer require --no-update \
    'php':'^8.1 || ^8.2 || ^8.3' \
    'fgtclb/category-types':'^1.1.0 || 1.*.*@dev' \
&& mv composer.json composer.json.orig \
&& cat <<< $(jq --indent 4 '."conflict" += {"fgtclb/category-types": "<1.0.0 || >=2.0.0"}' composer.json.orig) > composer.json \
&& rm -rf composer.json.orig
```
