### PR TITLE
[TASK] Cherry-pick compatibility branch changes

### DIFF
--- a/Classes/Domain/Model/Project.php
+++ b/Classes/Domain/Model/Project.php
@@ -55,6 +55,9 @@ class Project extends AbstractEntity
         return $this->title;
     }
 
+    /**
+     * @return ObjectStorage<FileReference>
+     */
     public function getMedia(): ObjectStorage
     {
         return $this->media;

--- a/Classes/Domain/Repository/ProjectRepository.php
+++ b/Classes/Domain/Repository/ProjectRepository.php
@@ -12,6 +12,9 @@ use TYPO3\CMS\Core\Type\Exception\InvalidEnumerationValueException;
 use TYPO3\CMS\Extbase\Persistence\Generic\QueryResult;
 use TYPO3\CMS\Extbase\Persistence\Repository;
 
+/**
+ * @extends Repository<Project>
+ */
 class ProjectRepository extends Repository
 {
     /**
@@ -44,7 +47,7 @@ class ProjectRepository extends Repository
         if ($demand->getHideCompletedProjects() === true) {
             $constraints[] = $query->logicalOr([
                 $query->equals('txAcademicprojectsEndDate', 0),
-                $query->greaterThan('txAcademicprojectsEndDate', new DateTime())
+                $query->greaterThan('txAcademicprojectsEndDate', new DateTime()),
             ]);
         }
 

--- a/Classes/ViewHelpers/Form/AbstractSelectViewHelper.php
+++ b/Classes/ViewHelpers/Form/AbstractSelectViewHelper.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicProjects\ViewHelpers\Form;
 
-use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
 use TYPO3\CMS\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper;
 
 class AbstractSelectViewHelper extends AbstractFormFieldViewHelper

--- a/Classes/ViewHelpers/Form/AbstractSelectViewHelper.php
+++ b/Classes/ViewHelpers/Form/AbstractSelectViewHelper.php
@@ -4,17 +4,69 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicProjects\ViewHelpers\Form;
 
-class AbstractSelectViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Form\SelectViewHelper
+use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
+use TYPO3\CMS\Fluid\ViewHelpers\Form\AbstractFormFieldViewHelper;
+
+class AbstractSelectViewHelper extends AbstractFormFieldViewHelper
 {
+    /**
+     * @var string
+     */
+    protected $tagName = 'select';
+
+    /**
+     * @var string
+     */
+    protected $selectedValue;
+
     public function initializeArguments(): void
     {
         parent::initializeArguments();
-        $this->registerArgument('renderOptions', 'bool', 'If true, options will be rendered. Otherwise an "options" variable is created for custom rendering in the template.', false, true);
+
+        $arguments = [
+            'options' => [
+                'type' => 'array',
+                'defaultValue' => [],
+                'description' => 'Associative array with internal IDs as key, and the values are displayed in the select box. Can be combined with or replaced by child f:form.select.* nodes.',
+            ],
+            'optionsAfterContent' => [
+                'type' => 'boolean',
+                'defaultValue' => false,
+                'description' => 'If true, places auto-generated option tags after those rendered in the tag content. If false, automatic options come first.',
+            ],
+            'sortByOptionLabel' => [
+                'type' => 'boolean',
+                'defaultValue' => false,
+                'description' => 'If true, List will be sorted by label.',
+            ],
+            'errorClass' => [
+                'type' => 'string',
+                'defaultValue' => 'f3-form-error',
+                'description' => 'CSS class to set if there are errors for this ViewHelper',
+            ],
+            'prependOptionLabel' => [
+                'type' => 'string',
+                'description' => 'If specified, will provide an option at first position with the specified label.',
+            ],
+            'prependOptionValue' => [
+                'type' => 'string',
+                'description' => 'If specified, will provide an option at first position with the specified value.',
+            ],
+            'required' => [
+                'type' => 'boolean',
+                'defaultValue' => false,
+                'description' => 'If set no empty value is allowed.',
+            ],
+            'renderOptions' => [
+                'type' => 'bool',
+                'defaultValue' => true,
+                'description' => 'If true, options will be rendered. Otherwise an "options" variable is created for custom rendering in the template.',
+            ],
+        ];
+
+        $this->registerArguments($arguments);
     }
 
-    /**
-     * @return string
-     */
     public function render(): string
     {
         if (isset($this->arguments['required']) && $this->arguments['required']) {
@@ -22,15 +74,13 @@ class AbstractSelectViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Form\SelectV
         }
 
         $name = $this->getName();
-        if (isset($this->arguments['multiple']) && $this->arguments['multiple']) {
-            $this->tag->addAttribute('multiple', 'multiple');
-            $name .= '[]';
-        }
         $this->tag->addAttribute('name', $name);
 
         $options = $this->getOptions();
 
-        if (isset($this->arguments['renderOptions']) && (bool)$this->arguments['renderOptions'] === false) {
+        if (isset($this->arguments['renderOptions'])
+            && (bool)$this->arguments['renderOptions'] === false
+        ) {
             $this->renderingContext->getVariableProvider()->add('options', $options);
         }
 
@@ -43,33 +93,12 @@ class AbstractSelectViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Form\SelectV
         // Register field name for token generation.
         $this->registerFieldNameForFormTokenGeneration($name);
 
-        // In case it is a multi-select, we need to register the field name
-        // as often as there are elements in the box
-        if (isset($this->arguments['multiple']) && $this->arguments['multiple']) {
-            $content .= $this->renderHiddenFieldForEmptyValue();
-
-            // Register the field name additional times as required by the total number of
-            // options. Since we already registered it once above, we start the counter at 1
-            // instead of 0.
-            $optionsCount = count($options);
-            for ($i = 1; $i < $optionsCount; $i++) {
-                $this->registerFieldNameForFormTokenGeneration($name);
-            }
-
-            // Save the parent field name so that any child f:form.select.option
-            // tag will know to call registerFieldNameForFormTokenGeneration
-            // this is the reason why "self::class" is used instead of static::class (no LSB)
-            $viewHelperVariableContainer->addOrUpdate(
-                self::class,
-                'registerFieldNameForFormTokenGeneration',
-                $name
-            );
-        }
-
         $prependContent = $this->renderPrependOptionTag();
 
         $tagContent = '';
-        if (isset($this->arguments['renderOptions']) && (bool)$this->arguments['renderOptions'] === true) {
+        if (isset($this->arguments['renderOptions'])
+            && (bool)$this->arguments['renderOptions'] === true
+        ) {
             $tagContent = $this->renderOptionTags($options);
         }
 
@@ -95,5 +124,84 @@ class AbstractSelectViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\Form\SelectV
         $content .= $this->tag->render();
 
         return $content;
+    }
+
+    protected function renderPrependOptionTag(): string
+    {
+        $output = '';
+        if ($this->hasArgument('prependOptionLabel')) {
+            $value = $this->hasArgument('prependOptionValue') ? $this->arguments['prependOptionValue'] : '';
+            $label = $this->arguments['prependOptionLabel'];
+            $output .= $this->renderOptionTag((string)$value, (string)$label, false) . LF;
+        }
+        return $output;
+    }
+
+    /**
+     * @param array<string, mixed> $arguments
+     */
+    protected function registerArguments(array $arguments): void
+    {
+        foreach ($arguments as $argumentName => $argumentConfiguration) {
+            $this->registerArgument(
+                $argumentName,
+                $argumentConfiguration['type'],
+                $argumentConfiguration['description'],
+                $argumentConfiguration['required'] ?? false,
+                $argumentConfiguration['defaultValue'] ?? null,
+                $argumentConfiguration['escape'] ?? null
+            );
+        }
+    }
+
+    protected function getSelectedValue(): string
+    {
+        $this->setRespectSubmittedDataValue(true);
+        return $this->getValueAttribute();
+    }
+
+    protected function isSelected(string $value): bool
+    {
+        $selectedValue = $this->getSelectedValue();
+
+        if ($value === $selectedValue || (string)$value === $selectedValue) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int, mixed> $options
+     */
+    protected function renderOptionTags($options): string
+    {
+        $output = '';
+        foreach ($options as $option) {
+            $output .= '<option value="' . $option['value'] . '"';
+            if ($option['isSelected']) {
+                $output .= ' selected="selected"';
+            }
+            $output .= '>' . htmlspecialchars((string)$option['label']) . '</option>' . LF;
+        }
+        return $output;
+    }
+
+    protected function renderOptionTag(string $value, string $label, bool $isSelected): string
+    {
+        $output = '<option value="' . htmlspecialchars((string)$value) . '"';
+        if ($isSelected) {
+            $output .= ' selected="selected"';
+        }
+        $output .= '>' . htmlspecialchars((string)$label) . '</option>';
+        return $output;
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    protected function getOptions()
+    {
+        return [];
     }
 }

--- a/Classes/ViewHelpers/Form/FilterSelectViewHelper.php
+++ b/Classes/ViewHelpers/Form/FilterSelectViewHelper.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace FGTCLB\AcademicProjects\ViewHelpers\Form;
 
-class DemandSelectViewHelper extends AbstractSelectViewHelper
+class FilterSelectViewHelper extends AbstractSelectViewHelper
 {
     public function initializeArguments(): void
     {
@@ -112,7 +112,7 @@ class DemandSelectViewHelper extends AbstractSelectViewHelper
      * @param array<int, mixed> $options
      * @return string
      */
-    protected function renderOptionTags($options)
+    protected function renderOptionTags($options): string
     {
         $output = '';
         foreach ($options as $value => $option) {

--- a/Configuration/CategoryTypes.yaml
+++ b/Configuration/CategoryTypes.yaml
@@ -1,0 +1,21 @@
+groups:
+  - identifier: projects
+    title: 'LLL:EXT:academic_projects/Resources/Private/Language/locallang.xlf:category_group.projects'
+    icon: 'EXT:academic_projects/Resources/Public/Icons/CategoryGroups/Projects.svg'
+types:
+  - identifier: competence_field
+    title: 'LLL:EXT:academic_projects/Resources/Private/Language/locallang.xlf:category_type.competence_field'
+    group: projects
+    icon: 'EXT:academic_projects/Resources/Public/Icons/CategoryTypes/CompetenceField.svg'
+  - identifier: cooperation
+    title: 'LLL:EXT:academic_projects/Resources/Private/Language/locallang.xlf:category_type.cooperation'
+    group: projects
+    icon: 'EXT:academic_projects/Resources/Public/Icons/CategoryTypes/Cooperation.svg'
+  - identifier: funding_partner
+    title: 'LLL:EXT:academic_projects/Resources/Private/Language/locallang.xlf:category_type.funding_partner'
+    group: projects
+    icon: 'EXT:academic_projects/Resources/Public/Icons/CategoryTypes/FundingPartner.svg'
+  - identifier: department
+    title: 'LLL:EXT:academic_projects/Resources/Private/Language/locallang.xlf:category_type.department'
+    group: projects
+    icon: 'EXT:academic_projects/Resources/Public/Icons/CategoryTypes/Department.svg'

--- a/Configuration/Icons.php
+++ b/Configuration/Icons.php
@@ -3,15 +3,15 @@
 declare(strict_types=1);
 
 use FGTCLB\AcademicProjects\Enumeration\CategoryTypes;
+use TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-$sourceString = function (string $icon) {
-    return sprintf(
-        'EXT:academic_projects/Resources/Public/Icons/CategoryTypes/%s.svg',
-        \TYPO3\CMS\Core\Utility\GeneralUtility::underscoredToUpperCamelCase($icon)
-    );
-};
+$sourceString = static fn (string $icon): string => sprintf(
+    'EXT:academic_projects/Resources/Public/Icons/CategoryTypes/%s.svg',
+    GeneralUtility::underscoredToUpperCamelCase($icon)
+);
 
-$identifierString = function (string $identifier) {
+$identifierString = static function (string $identifier) {
     return sprintf(
         'academic-project-%s',
         $identifier
@@ -20,19 +20,19 @@ $identifierString = function (string $identifier) {
 
 return [
     $identifierString(CategoryTypes::TYPE_COMPETENCE_FIELD) => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => $sourceString(CategoryTypes::TYPE_COMPETENCE_FIELD),
     ],
     $identifierString(CategoryTypes::TYPE_COOPERATION) => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => $sourceString(CategoryTypes::TYPE_COOPERATION),
     ],
     $identifierString(CategoryTypes::TYPE_DEPARTMENT) => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => $sourceString(CategoryTypes::TYPE_DEPARTMENT),
     ],
     $identifierString(CategoryTypes::TYPE_FUNDING_PARTNER) => [
-        'provider' => \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
+        'provider' => SvgIconProvider::class,
         'source' => $sourceString(CategoryTypes::TYPE_FUNDING_PARTNER),
     ],
 ];

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -91,7 +91,10 @@ if (!defined('TYPO3')) {
             'config' => [
                 'type' => 'input',
                 'renderType' => 'inputDateTime',
-                'eval' => 'date,int',
+                'eval' => implode(',', [
+                    'date',
+                    'int',
+                ]),
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],
@@ -103,7 +106,10 @@ if (!defined('TYPO3')) {
             'config' => [
                 'type' => 'input',
                 'renderType' => 'inputDateTime',
-                'eval' => 'date,int',
+                'eval' => implode(',', [
+                    'date',
+                    'int',
+                ]),
                 'behaviour' => [
                     'allowLanguageSynchronization' => true,
                 ],

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -58,8 +58,8 @@
 				<source>Akademische Seiten</source>
 			</trans-unit>
 			<trans-unit id="pages.doktype.item.academic_projects">
-				<source>Academic Projects</source>
-				<target>Akademische Projekte</target>
+				<source>Academic Project</source>
+				<target>Akademisches Projekt</target>
 			</trans-unit>
 		</body>
 	</file>


### PR DESCRIPTION

This change cherry-picks a couple of commits from
the compatibility branch as preparation to be added
to the planned monorepo directly, leaving only the
last commit out setting v12/v13 constraints.

Used command(s):

```shell
git cherry-pick 18dd33d..bcc9146
```


- **[TASK] Apply consistent doktype naming**
  

- **[TASK] Add annotations for PHPStan**
  

- **[TASK] Optimize TCA for pages overrides**
  

- **[TASK] Copy changes on select view helpers from academic_programs**
  

- **[TASK] Optimze icon handling**
  

- **[TASK] Apply php-cs-fixer changes**
  

- **[TASK] Add category types YAML configuration**
  