### PR TITLE
[TASK] Streamline GitHub action workflow publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,21 +3,25 @@ on:
   push:
     tags:
       - '*'
+
 jobs:
   publish:
-    name: Publish new version to TER
+    name: Ensure GitHub Release with extension TER artifact and publishing to TER
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
       TYPO3_API_TOKEN: ${{ secrets.TYPO3_API_TOKEN }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Check tag
+      - name: Verify tag
         run: |
           if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
+            echo "ERR: Invalid publish version tag: ${{ github.ref }}"
             exit 1
           fi
 
@@ -28,13 +32,19 @@ jobs:
       - name: Get comment
         id: get-comment
         run: |
-          readonly local comment=$(git tag -n10 -l ${{ env.version }} | sed "s/^[0-9.]*[ ]*//g")
-
-          if [[ -z "${comment// }" ]]; then
-            echo "comment=Released version ${{ env.version }} of ${{ env.TYPO3_EXTENSION_KEY }}" >> $GITHUB_ENV
-          else
-            echo "comment=$comment" >> $GITHUB_ENV
+          readonly local releaseCommentPrependBody="$( git tag -l ${{ env.version }} --format '%(contents)' )"
+          if (( $(grep -c . <<<"${releaseCommentPrependBody// }") > 1 )); then
+            {
+              echo 'releaseCommentPrependBody<<EOF'
+              echo "$releaseCommentPrependBody"
+              echo EOF
+            } >> "$GITHUB_ENV"
           fi
+          {
+            echo 'terReleaseNotes<<EOF'
+            echo "https://github.com/fgtclb/academic-persons/releases/tag/${{ env.version }}"
+            echo EOF
+          } >> "$GITHUB_ENV"
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -46,5 +56,32 @@ jobs:
       - name: Install tailor
         run: composer global require typo3/tailor --prefer-dist --no-progress --no-suggest
 
+      # Note that step will fail when `env.version` does not match the `ext_emconf.php` version.
+      - name: Create local TER package upload artifact
+        run: |
+          php ~/.composer/vendor/bin/tailor create-artefact ${{ env.version }}
+
+      # Note that when release already exists for tag, only files will be uploaded and lets this acting as a
+      # fallback to ensure that a real GitHub release is created for the tag along with extension artifacts.
+      - name: Create release and upload artifacts in the same step
+        uses: softprops/action-gh-release@v2
+        if: ${{startsWith(github.ref, 'refs/tags/') }}
+        with:
+          name: "[RELEASE] ${{ env.version }}"
+          body: "${{ env.releaseCommentPrependBody }}"
+          generate_release_notes: true
+          files: |
+            tailor-version-artefact/${{ env.TYPO3_EXTENSION_KEY }}_${{ env.version }}.zip
+            LICENSE
+          fail_on_unmatched_files: true
+
+      # @todo Currently an issue exists with the TYPO3 Extension Repository (TER) tailor based uploads, which seems to
+      #       be WAF related and the T3O TER Team working on. Allow this step to fail (continue on error) for now until
+      #       issues has been sorted out.
+      #       https://github.com/TYPO3/tailor/issues/82
       - name: Publish to TER
-        run: php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ env.comment }}" ${{ env.version }}
+        # @todo Remove `continue-on-error` after upload with tailor has been fixed.
+        continue-on-error: true
+        run: |
+          php ~/.composer/vendor/bin/tailor ter:publish --comment "${{ env.terReleaseNotes }}" ${{ env.version }} \
+            --artefact=tailor-version-artefact/${{ env.TYPO3_EXTENSION_KEY }}_${{ env.version }}.zip

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 
 /.cache/
 /Build/testing-docker/.env
+
+/tailor-version-artefact/
+/tailor-version-upload/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,79 @@
+# TYPO3 extension `academic_projects`
+
+## Installation
+
+Install with your flavour:
+
+* [TER](https://extensions.typo3.org/extension/academic_projects/)
+* Extension Manager
+* composer
+
+We prefer composer installation:
+```bash
+composer req fgtclb/academic-projects
+```
+
+|                  | URL                                                           |
+|------------------|---------------------------------------------------------------|
+| **Repository:**  | https://github.com/fgtclb/academic-projects                   |
+| **Read online:** | https://docs.typo3.org/p/fgtclb/academic-projects/main/en-us/ |
+| **TER:**         | https://extensions.typo3.org/extension/academic_projects/     |
+
+
+## Create a release (maintainers only)
+
+Prerequisites:
+
+* git binary
+* ssh key allowed to push new branches to the repository
+* GitHub command line tool `gh` installed and configured with user having permission to create pull requests.
+
+**Prepare release locally**
+
+> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main'.
+> Set `RELEASE_VERSION` to release version working on, for example: '1.1.0'.
+
+```shell
+echo '>> Prepare release pull-request' ; \
+  RELEASE_BRANCH='main' ; \
+  RELEASE_VERSION='1.1.0' ; \
+  git checkout main && \
+  git fetch --all && \
+  git pull --rebase && \
+  git checkout ${RELEASE_BRANCH} && \
+  git pull --rebase && \
+  git checkout -b prepare-release-${RELEASE_VERSION} && \
+  composer require --dev "typo3/tailor" && \
+  ./.Build/bin/tailor set-version ${RELEASE_VERSION} && \
+  composer remove --dev "typo3/tailor" && \
+  git add . && \
+  git commit -m "[RELEASE] ${RELEASE_VERSION}" && \
+  git push --set-upstream origin prepare-release-${RELEASE_VERSION} && \
+  gh pr create --fill-verbose --base ${RELEASE_BRANCH} --title "[RELEASE] ${RELEASE_VERSION}" && \
+  git checkout main && \
+  git branch -D prepare-release-${RELEASE_VERSION}
+```
+
+Check pull-request and the pipeline run.
+
+**Merge approved pull-request and push version tag**
+
+> Set `RELEASE_PR_NUMBER` with the pull-request number of the preparation pull-request.
+> Set `RELEASE_BRANCH` to branch release should happen, for example: 'main' (same as in previous step).
+> Set `RELEASE_VERSION` to release version working on, for example: `1.1.0` (same as in previous step).
+
+```shell
+RELEASE_BRANCH='main' ; \
+RELEASE_VERSION='1.1.0' ; \
+RELEASE_PR_NUMBER='123' ; \
+  git checkout main && \
+  git fetch --all && \
+  git pull --rebase && \
+  gh pr checkout ${RELEASE_PR_NUMBER} && \
+  gh pr merge -rd ${RELEASE_PR_NUMBER} && \
+  git tag ${RELEASE_VERSION} && \
+  git push --tags
+```
+
+This triggers the `on push tags` workflow (`publish.yml`) which creates the upload package,
+creates the GitHub release and also uploads the release to the TYPO3 Extension Repository.


### PR DESCRIPTION
The current `publish` github action workflow is
streamlined to work in a more smoother way and
also respect current broken automatic releasing
with tailor to the TYPO3 Extension Registry.

This includes:

* Using a simpler way to get the tag message for
  requested version based on the tag and avoid
  sed issues. Makes the part a little bit more
  obvious.
* Using tailor to create an upload artifact in
  a first step.
* Create an github release from the tag using
  the extracted tag message as prepand message
  along with attaching the tailor upload pack
  artifact to the release. If release already
  exists, only the artifact is attached.
* Try uploading created upload artifact to the
  TER, but do not fail in case it does not work
  yet. **Be aware** that this must checked manually,
  but attached artifact can simply be used to
  upload it manually to TER mitigating the need
  to build it locally again for the tag.
* Add missing `README.md` to document required
  release workflow for maintainers and basic
  information.
